### PR TITLE
[ntuple] h1, cms: minor fix required after merging RNTuple binary format v1

### DIFF
--- a/cms.cxx
+++ b/cms.cxx
@@ -180,11 +180,11 @@ static void NTupleDirect(const std::string &path) {
    auto hMass = new TH1D("Dimuon_mass", "Dimuon_mass", 2000, 0.25, 300);
 
    auto viewMuon = ntuple->GetViewCollection("nMuon");
-   auto viewMuonCharge = viewMuon.GetView<std::int32_t>("nMuon.Muon_charge");
-   auto viewMuonPt = viewMuon.GetView<float>("nMuon.Muon_pt");
-   auto viewMuonEta = viewMuon.GetView<float>("nMuon.Muon_eta");
-   auto viewMuonPhi = viewMuon.GetView<float>("nMuon.Muon_phi");
-   auto viewMuonMass = viewMuon.GetView<float>("nMuon.Muon_mass");
+   auto viewMuonCharge = viewMuon.GetView<std::int32_t>("_0.Muon_charge");
+   auto viewMuonPt = viewMuon.GetView<float>("_0.Muon_pt");
+   auto viewMuonEta = viewMuon.GetView<float>("_0.Muon_eta");
+   auto viewMuonPhi = viewMuon.GetView<float>("_0.Muon_phi");
+   auto viewMuonMass = viewMuon.GetView<float>("_0.Muon_mass");
 
    std::chrono::steady_clock::time_point ts_first = std::chrono::steady_clock::now();
    for (auto entryId : ntuple->GetEntryRange()) {

--- a/h1.cxx
+++ b/h1.cxx
@@ -279,11 +279,11 @@ static void NTupleDirect(const std::string &path) {
    auto md0_dView = ntuple->GetView<float>("event.md0_d");
 
    auto trackView = ntuple->GetViewCollection("event.tracks");
-   auto nhitrpView = ntuple->GetView<std::int32_t>("event.tracks.H1Event::Track.nhitrp");
-   auto rstartView = ntuple->GetView<float>("event.tracks.H1Event::Track.rstart");
-   auto rendView = ntuple->GetView<float>("event.tracks.H1Event::Track.rend");
-   auto nlhkView = ntuple->GetView<float>("event.tracks.H1Event::Track.nlhk");
-   auto nlhpiView = ntuple->GetView<float>("event.tracks.H1Event::Track.nlhpi");
+   auto nhitrpView = ntuple->GetView<std::int32_t>("event.tracks._0.nhitrp");
+   auto rstartView = ntuple->GetView<float>("event.tracks._0.rstart");
+   auto rendView = ntuple->GetView<float>("event.tracks._0.rend");
+   auto nlhkView = ntuple->GetView<float>("event.tracks._0.nlhk");
+   auto nlhpiView = ntuple->GetView<float>("event.tracks._0.nlhpi");
    auto njetsView = ntuple->GetViewCollection("event.jets");
 
    std::chrono::steady_clock::time_point ts_first = std::chrono::steady_clock::now();


### PR DESCRIPTION
According to RNTuple binary format v1 specification, [section std::vector<T> and ROOT::RVec<T>](https://github.com/root-project/root/blob/master/tree/ntuple/v7/doc/specifications.md#stdvector-and-rootrvec), the name of the child field of a `std::vector<T>` is now `_0`.

`RNTupleH1Benchmarks.cxx` (in the rootbench repository) was also updated accordingly.

This PR fixes the dot-paths in cms.cxx and h1.cxx.