### PR TITLE
[gen_lhcb,gen_physlite] Fixes after merging ROOT pull-request #9317

### DIFF
--- a/gen_lhcb.cxx
+++ b/gen_lhcb.cxx
@@ -100,7 +100,10 @@ int main(int argc, char **argv) {
       // Hand over ownership of the field to the ntuple model.  This will also create a memory location attached
       // to the model's default entry, that will be used to place the data supposed to be written
       model->AddField(std::move(field));
-
+   }
+   model->Freeze();
+   for (auto b : TRangeDynCast<TBranch>(*tree->GetListOfBranches())) {
+      TLeaf *l = static_cast<TLeaf*>(b->GetListOfLeaves()->First());
       // We connect the model's default entry's memory location for the new field to the branch, so that we can
       // fill the ntuple with the data read from the TTree
       void *fieldDataPtr = model->GetDefaultEntry()->GetValue(l->GetName()).GetRawPtr();

--- a/gen_physlite.cxx
+++ b/gen_physlite.cxx
@@ -25,6 +25,7 @@
 #include "util.h"
 
 using RCollectionNTupleWriter = ROOT::Experimental::RCollectionNTupleWriter;
+using REntry = ROOT::Experimental::REntry;
 using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
 using RNTupleModel = ROOT::Experimental::RNTupleModel;
 using RNTupleWriteOptions = ROOT::Experimental::RNTupleWriteOptions;
@@ -53,6 +54,7 @@ struct LeafCountCollection {
    std::string treeName;
    std::string ntupleName;
    std::vector<FlatField> collectionFields;
+   std::unique_ptr<REntry> entry;
    std::shared_ptr<RCollectionNTupleWriter> collectionWriter;
    int count = 0; // TODO: this can be also an uint or something else ?
 
@@ -159,7 +161,7 @@ int main(int argc, char **argv)
       flatFields.erase(needle);
 
       //std::cout << "SetBranchAddress " << c->treeName << std::endl;
-      auto collectionModel = RNTupleModel::Create();
+      auto collectionModel = RNTupleModel::CreateBare();
       for (auto &f : c->collectionFields) {
          auto field = RFieldBase::Create(f.ntupleName, f.typeName).Unwrap();
          f.fldSize = field->GetValueSize();
@@ -170,8 +172,12 @@ int main(int argc, char **argv)
          //collectionModel->AddField(std::move(field));
          //fDefaultEntry->AddValue(field->GenerateValue());
          f.ntupleBuffer = std::make_unique<unsigned char []>(field->GetValueSize());
-         collectionModel->GetDefaultEntry()->CaptureValue(field->CaptureValue(f.ntupleBuffer.get()));
          collectionModel->GetFieldZero()->Attach(std::move(field));
+      }
+      collectionModel->Freeze();
+      c->entry = collectionModel->CreateBareEntry();
+      for (auto &f : c->collectionFields) {
+         c->entry->CaptureValueUnsafe(f.ntupleName, f.ntupleBuffer.get());
       }
       tree->SetBranchAddress(c->treeName.c_str(), (void *)&c->count);
 
@@ -183,7 +189,9 @@ int main(int argc, char **argv)
 
       auto field = RFieldBase::Create(f.ntupleName, f.typeName).Unwrap();
       model->AddField(std::move(field));
-
+   }
+   model->Freeze();
+   for (auto &f : flatFields) {
       // We connect the model's default entry's memory location for the new field to the branch, so that we can
       // fill the ntuple with the data read from the TTree
       void *fieldDataPtr = model->GetDefaultEntry()->GetValue(f.ntupleName).GetRawPtr();

--- a/gen_physlite.cxx
+++ b/gen_physlite.cxx
@@ -200,7 +200,7 @@ int main(int argc, char **argv)
 
    RNTupleWriteOptions options;
    options.SetCompression(compressionSettings);
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), "Events", outputFile, options);
+   auto ntuple = RNTupleWriter::Recreate(std::move(model), treeName, outputFile, options);
 
    auto nEntries = tree->GetEntries();
    for (decltype(nEntries) i = 0; i < nEntries; ++i) {


### PR DESCRIPTION
This pull-request applies the required changes to `gen_lhcb.cxx` and `gen_physlite.cxx` to make them compile after merging PR [#9317](https://github.com/root-project/root/pull/9317) that brings improvements to the RNTuple write API.

Note that this PR only applies changes to those two files.  Additional changes might be required to compile other programs in the repository.