### PR TITLE
Add a tool to dump RNTuple pages and metadata to separate files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,9 @@ include_cms/libClasses.so: include_cms/classes.cxx
 ntuple_info: ntuple_info.C include_cms/libClasses.so libH1event.so
 	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 
+ntuple_dump: ntuple_dump.C
+	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
+
 tree_info: tree_info.C
 	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 
@@ -527,7 +530,7 @@ graph_%.pdf: graph_%.root
 ### CLEAN ######################################################################
 
 clean:
-	rm -f util.o lhcb cms_dimuon gen_lhcb gen_cms gen_cms_schema ntuple_info tree_info fuse_forward clock
+	rm -f util.o lhcb cms_dimuon gen_lhcb gen_cms gen_cms_schema ntuple_info ntuple_dump tree_info fuse_forward clock
 	rm -rf _make_ttjet_13tev_june2019*
 	rm -rf include_cms
 	rm -f libH1event.so libH1Dict.cxx

--- a/ntuple_dump.C
+++ b/ntuple_dump.C
@@ -7,6 +7,7 @@
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RPageStorage.hxx>
 
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -182,6 +183,11 @@ int main(int argc, char *argv[]) {
    }
    if ((argc - optind) != 2 || dumpFlags == kDumpNone)
       Usage(argv[0]);
+
+   if (!std::filesystem::is_directory(outputPath)) {
+      fprintf(stderr, "'%s' is not a directory\n", outputPath.c_str());
+      exit(1);
+   }
 
    auto source = RPageSource::Create(argv[optind + 1], argv[optind], RNTupleReadOptions());
    source->Attach();

--- a/ntuple_dump.C
+++ b/ntuple_dump.C
@@ -1,0 +1,116 @@
+/**
+ * Copyright CERN; j.lopez@cern.ch
+ */
+
+#include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RPageStorage.hxx>
+
+#include <fstream>
+#include <memory>
+#include <unistd.h>
+
+using RColumnDescriptor = ROOT::Experimental::RColumnDescriptor;
+using RFieldDescriptor = ROOT::Experimental::RFieldDescriptor;
+using RNTupleDescriptor = ROOT::Experimental::RNTupleDescriptor;
+using RNTupleReadOptions = ROOT::Experimental::RNTupleReadOptions;
+using RPageSource = ROOT::Experimental::Detail::RPageSource;
+using RClusterIndex = ROOT::Experimental::RClusterIndex;
+
+/// \brief Helper class to dump RNTuple pages / metadata to separate files.
+///
+class RNTupleDumper {
+   std::unique_ptr<RPageSource> fSource;
+   const RPageSource::RSharedDescriptorGuard fDesc;
+
+   struct RColumnInfo {
+      const RColumnDescriptor &fColumnDesc;
+      const RFieldDescriptor &fFieldDesc;
+   };
+
+   void AddColumnsFromField(std::vector<RColumnInfo> &vec, const RFieldDescriptor &fieldDesc) {
+   }
+public:
+   RNTupleDumper(std::unique_ptr<RPageSource> source)
+     : fSource(std::move(source)), fDesc(source->GetSharedDescriptorGuard()) {}
+
+   /// Recursively collect all the columns for all the fields rooted at field zero.
+   std::vector<RColumnInfo> CollectColumns() {
+      std::vector<RColumnInfo> columns;
+      return columns;
+   }
+
+   /// Iterate over all the clusters and dump the contents of each page for each column.
+   /// Generated file names follow the template `filenameTmpl` and are placed in directory `outputPath`.
+   void DumpPages(const std::vector<RColumnInfo> &columns,
+		  const std::string &outputPath, const std::string &filenameTmpl) {
+   }
+
+   /// Dump ntuple header and footer to separate files.
+   void DumpMetadata(const std::string &outputPath) {
+   }
+};
+
+enum EDumpFlags {
+   kDumpNone = 0,
+   kDumpPages = 0x01,
+   kDumpMetadata = 0x02,
+};
+
+[[noreturn]]
+static void Usage(char *argv0) {
+   printf("Usage: %s [-p] [-m] [-o output-path] file-name ntuple-name\n\n", argv0);
+   printf("Options:\n");
+   printf("  -p\t\tDump pages for all the columns\n");
+   printf("  -m\t\tDump ntuple metadata\n");
+   printf("  -o output-path\tGenerated files will be written to output-path (defaults to `./`)\n");
+   printf("\nAt least one of `-p` or `-m` is required.\n");
+   exit(0);
+}
+
+int main(int argc, char *argv[]) {
+   std::string inputFile;
+   std::string ntupleName;
+   std::string outputPath{"./"};
+   std::string filenameTmpl{"cluster%d_%s_pg%d.page"};
+   unsigned dumpFlags = kDumpNone;
+
+   int c;
+   while ((c = getopt(argc, argv, "hpmo:")) != -1) {
+      switch (c) {
+      case 'p':
+	 dumpFlags |= kDumpPages;
+         break;
+      case 'm':
+	 dumpFlags |= kDumpMetadata;
+         break;
+      case 'o':
+	 outputPath = optarg;
+         break;
+      case 'h':
+      default:
+         Usage(argv[0]);
+      }
+   }
+   if ((argc - optind) != 2 || dumpFlags == kDumpNone)
+      Usage(argv[0]);
+
+   auto source = RPageSource::Create(argv[optind + 1], argv[optind], RNTupleReadOptions());
+   source->Attach();
+
+   RNTupleDumper dumper(std::move(source));
+   if (dumpFlags & kDumpMetadata) {
+      dumper.DumpMetadata(outputPath);
+   }
+   if (dumpFlags & kDumpPages) {
+      auto columns = dumper.CollectColumns();
+      for (const auto &C : columns) {
+         printf("Column %lu: %s[%lu]\n", (unsigned long)C.fColumnDesc.GetId(),
+                                         C.fFieldDesc.GetFieldName().c_str(),
+                                         (unsigned long)C.fColumnDesc.GetIndex());
+      }
+      dumper.DumpPages(columns, outputPath, filenameTmpl);
+   }
+
+   return 0;
+}


### PR DESCRIPTION
This pull request adds `ntuple_dump`, a tool to dump RNTuple pages and metadata (header, footer and page lists) to separate files (see usage below).

```bash
$ ./ntuple_dump
Usage: ./ntuple_dump [-p] [-m] [-o output-path] file-name ntuple-name

Options:
  -p	        Dump pages for all the columns
  -m	        Dump ntuple metadata
  -o output-path	Generated files will be written to output-path (defaults to `./`)

At least one of `-p` or `-m` is required.
```

A page is dumped as-is (i.e., compressed if it was stored compressed in the original file; uncompressed otherwise).  Metadata is always dumped in uncompressed form.  The tool will generate the following files in the output directory:
- If `-p` is specified, for each page, a file named `clusterN_C_pgI.page` with the contents of page `I` of column `C` in cluster `N`.
- If `-m` is specified, (i) for each cluster group, a `cgN.pagelist` containing the page list of cluster group `N`; and (ii) the `header` and `footer` files, containing the ntuple header and footer, respectively.