### PR TITLE
Add huge file tests

### DIFF
--- a/compare/hugefile/Makefile
+++ b/compare/hugefile/Makefile
@@ -4,7 +4,7 @@ LDFLAGS =
 LDFLAGS_ROOT = $(shell root-config --libs) -lROOTNTuple
 LDFLAGS_HDF5 = -lhdf5
 LDFLAGS_PARQUET = -larrow -lparquet
-BIN = test_ttree test_ntuple test_parquet
+BIN = test_ttree test_ntuple test_parquet test_h5_row test_h5_column
 
 .PHONY = clean h5hep
 
@@ -28,3 +28,9 @@ test_ntuple: test_ntuple.cc main.o
 
 test_parquet: test_parquet.cc main.o
 	g++ $(CXXFLAGS) -o $@ $^ $(LDFLAGS_PARQUET) $(LDFLAGS)
+
+test_h5_row: test_h5.cc main.o
+	g++ $(CXXFLAGS) -D__COLUMN_MODEL__=h5hep::ColumnModel::COMPOUND_TYPE -o $@ $^ $(LDFLAGS_HDF5) $(LDFLAGS)
+
+test_h5_column: test_h5.cc main.o
+	g++ $(CXXFLAGS) -D__COLUMN_MODEL__=h5hep::ColumnModel::COLUMNAR_FNAL -o $@ $^ $(LDFLAGS_HDF5) $(LDFLAGS)

--- a/compare/hugefile/Makefile
+++ b/compare/hugefile/Makefile
@@ -1,0 +1,24 @@
+CXXFLAGS = -std=c++17 -Wall -pthread -g -O3 -I../h5hep -I.. -DNDEBUG
+CXXFLAGS_ROOT = $(shell root-config --cflags)
+LDFLAGS =
+LDFLAGS_ROOT = $(shell root-config --libs) -lROOTNTuple
+LDFLAGS_HDF5 = -lhdf5
+LDFLAGS_PARQUET = -larrow -lparquet
+BIN = test_ttree
+
+.PHONY = clean h5hep
+
+all: h5hep $(BIN)
+
+clean:
+	make -C ../ -f Makefile.h5hep clean
+	rm -f $(BIN) *.o
+
+h5hep:
+	make -C ../ -f Makefile.h5hep h5hep
+
+%.o: %.cc
+	g++ $(CXXFLAGS) -c -o $@ $^
+
+test_ttree: test_ttree.cc main.o
+	g++ $(CXXFLAGS) $(CXXFLAGS_ROOT) -o $@ $^ $(LDFLAGS_ROOT) $(LDFLAGS)

--- a/compare/hugefile/Makefile
+++ b/compare/hugefile/Makefile
@@ -4,7 +4,7 @@ LDFLAGS =
 LDFLAGS_ROOT = $(shell root-config --libs) -lROOTNTuple
 LDFLAGS_HDF5 = -lhdf5
 LDFLAGS_PARQUET = -larrow -lparquet
-BIN = test_ttree test_ntuple
+BIN = test_ttree test_ntuple test_parquet
 
 .PHONY = clean h5hep
 
@@ -25,3 +25,6 @@ test_ttree: test_ttree.cc main.o
 
 test_ntuple: test_ntuple.cc main.o
 	g++ $(CXXFLAGS) $(CXXFLAGS_ROOT) -o $@ $^ $(LDFLAGS_ROOT) $(LDFLAGS)
+
+test_parquet: test_parquet.cc main.o
+	g++ $(CXXFLAGS) -o $@ $^ $(LDFLAGS_PARQUET) $(LDFLAGS)

--- a/compare/hugefile/Makefile
+++ b/compare/hugefile/Makefile
@@ -4,7 +4,7 @@ LDFLAGS =
 LDFLAGS_ROOT = $(shell root-config --libs) -lROOTNTuple
 LDFLAGS_HDF5 = -lhdf5
 LDFLAGS_PARQUET = -larrow -lparquet
-BIN = test_ttree
+BIN = test_ttree test_ntuple
 
 .PHONY = clean h5hep
 
@@ -21,4 +21,7 @@ h5hep:
 	g++ $(CXXFLAGS) -c -o $@ $^
 
 test_ttree: test_ttree.cc main.o
+	g++ $(CXXFLAGS) $(CXXFLAGS_ROOT) -o $@ $^ $(LDFLAGS_ROOT) $(LDFLAGS)
+
+test_ntuple: test_ntuple.cc main.o
 	g++ $(CXXFLAGS) $(CXXFLAGS_ROOT) -o $@ $^ $(LDFLAGS_ROOT) $(LDFLAGS)

--- a/compare/hugefile/main.cc
+++ b/compare/hugefile/main.cc
@@ -1,0 +1,40 @@
+#include <cstdio>
+#include <cstdlib>
+#include <unistd.h>
+#include <string>
+
+extern void Hugefile_Read(const std::string &filename);
+extern void Hugefile_Write(const std::string &filename, size_t nEntries);
+
+[[noreturn]]
+static void Usage(const char *argv0) {
+   printf("Usage: %s [-n n_entries] read|write path/to/file.ext\n", argv0);
+   exit(0);
+}
+
+int main(int argc, char *argv[]) {
+   size_t nEntries = 0;
+   int c;
+   while ((c = getopt(argc, argv, "hn:")) != -1) {
+      switch (c) {
+      case 'n':
+         nEntries = static_cast<size_t>(std::atol(optarg));
+         break;
+      case 'h':
+      default:
+         Usage(argv[0]);
+      }
+   }
+   if ((argc - optind) != 2)
+      Usage(argv[0]);
+
+   std::string op{argv[optind]};
+   std::string filename{argv[optind + 1]};
+   if (op == "read")
+      Hugefile_Read(filename);
+   else if (op == "write" && (nEntries != 0))
+      Hugefile_Write(filename, nEntries);
+   else
+      Usage(argv[0]);
+   return 0;
+}

--- a/compare/hugefile/run_tests.sh
+++ b/compare/hugefile/run_tests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+CLEAR_PAGE_CACHE=../../clear_page_cache
+DSTAT_INTERVAL=5
+DSTAT_OUT=/path/to/dstat_out
+OUTPUT_FILE=/path/to/output_file
+
+# If `dstat` is installed, statistics are collected every `$DSTAT_INTERVAL` seconds
+DSTAT=`which dstat 2>/dev/null`
+function dstat_start() {
+    if [ -n "$DSTAT" ]; then
+	dstat --nocolor --noupdate --cpu --mem --top-cpu --top-mem $DSTAT_INTERVAL >> $DSTAT_OUT &
+	DSTAT_PID=$!
+    fi
+}
+function dstat_stop() {
+    if [ -n "$DSTAT" ]; then kill $DSTAT_PID; fi
+}
+function collect_stats() {
+    dstat_start
+    time "$@"
+    dstat_stop
+}
+
+for TEST in test_{ntuple,ttree,parquet,h5_row,h5_column}; do
+    # ~10GB, ~100GB, ~250GB, ~1TB
+    for N_ENTRIES in 833333334 8333333334 20833333333 83333333334; do
+	echo -e "\n==== Starting test ./${TEST} -n $N_ENTRIES ===="
+	collect_stats ./${TEST} -n $N_ENTRIES write $OUTPUT_FILE
+	${CLEAR_PAGE_CACHE}
+	collect_stats ./${TEST} read $OUTPUT_FILE
+	rm -f $OUTPUT_FILE
+    done
+done

--- a/compare/hugefile/test_h5.cc
+++ b/compare/hugefile/test_h5.cc
@@ -1,0 +1,66 @@
+#include <h5hep/h5hep.hxx>
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+struct Entry {
+   float field0;
+   float field1;
+   float field2;
+};
+
+using Builder = h5hep::schema::SchemaBuilder<__COLUMN_MODEL__>;
+
+/// Chunk size defaults to RNTuple default page size divided by sizeof(float)
+static constexpr size_t kDefaultChunkSize = (64 * 1024) / sizeof(float);
+
+auto InitSchema() {
+   return Builder::MakeStructNode<Entry>("Entry", {
+       Builder::MakePrimitiveNode<float>("field_0", HOFFSET(Entry, field0)),
+       Builder::MakePrimitiveNode<float>("field_1", HOFFSET(Entry, field1)),
+       Builder::MakePrimitiveNode<float>("field_2", HOFFSET(Entry, field2)),
+     });
+}
+
+void Hugefile_Read(const std::string &filename) {
+   auto schema = InitSchema();
+   auto file = h5hep::H5File::Open(filename);
+   // Use the default RNTuple cluster size as the size for HDF5 chunk cache
+   std::static_pointer_cast<h5hep::H5File>(file)->SetCache(50 * 1000 * 1000);
+   auto reader = Builder::MakeReaderWriter(file, schema);
+
+   auto num_chunks = reader->GetNChunks();
+   auto chunk = std::make_unique<Entry[]>(reader->GetWriteProperties().GetChunkSize());
+
+   size_t count = 0;
+   for (size_t chunkIdx = 0; chunkIdx < num_chunks; ++chunkIdx) {
+      auto num_rows = reader->ReadChunk(chunkIdx, chunk.get());
+      count += num_rows;
+      printf("Read %lu entries\r", (unsigned long)count);
+   }
+}
+
+void Hugefile_Write(const std::string &filename, size_t nEntries) {
+   h5hep::WriteProperties props;
+   props.SetChunkSize(kDefaultChunkSize);
+   props.SetCompressionLevel(0);
+
+   auto schema = InitSchema();
+   auto file = h5hep::H5File::Create(filename);
+   // Use the default RNTuple cluster size as the size for HDF5 chunk cache
+   std::static_pointer_cast<h5hep::H5File>(file)->SetCache(50 * 1000 * 1000);
+   auto writer = Builder::MakeReaderWriter(file, schema, props);
+
+   h5hep::BufferedWriter<Entry> bw(writer);
+   Entry row;
+   for (size_t i = 0; i < nEntries; ++i) {
+      row.field0 = static_cast<float>(i);
+      row.field1 = static_cast<float>(i) + 0.1f;
+      row.field2 = static_cast<float>(i) + 1.1f;
+      bw.Write(row);
+      if (i % 10000 == 0)
+         printf("Wrote %lu entries\r", (unsigned long)i);
+   }
+   printf("Wrote %lu entries\n", (unsigned long)nEntries);
+}

--- a/compare/hugefile/test_ntuple.cc
+++ b/compare/hugefile/test_ntuple.cc
@@ -1,0 +1,58 @@
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+#include <TROOT.h>
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+using RNTupleModel = ROOT::Experimental::RNTupleModel;
+using RNTupleReader = ROOT::Experimental::RNTupleReader;
+using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
+using RNTupleWriteOptions = ROOT::Experimental::RNTupleWriteOptions;
+
+static constexpr const char *kNtupleName = "hugefile";
+
+void Hugefile_Read(const std::string &filename) {
+   ROOT::EnableImplicitMT();
+   auto model = RNTupleModel::Create();
+   auto ntuple = RNTupleReader::Open(std::move(model), kNtupleName, filename);
+
+   auto viewField0 = ntuple->GetView<float>("field_0");
+   auto viewField1 = ntuple->GetView<float>("field_1");
+   auto viewField2 = ntuple->GetView<float>("field_2");
+
+   for (auto i : ntuple->GetEntryRange()) {
+      (void)viewField0(i);
+      (void)viewField1(i);
+      (void)viewField2(i);
+      if (i % 10000 == 0)
+         printf("Read %lu entries\r", (unsigned long)i);
+   }
+   printf("Read %lu entries\n", (unsigned long)ntuple->GetNEntries());
+}
+
+void Hugefile_Write(const std::string &filename, size_t nEntries) {
+   ROOT::EnableImplicitMT();
+   auto model = RNTupleModel::Create();
+   std::shared_ptr<float> field[3];
+   for (size_t i = 0; i < std::extent<decltype(field)>::value; ++i) {
+      field[i] = model->MakeField<float>("field_" + std::to_string(i), 0.0f);
+   }
+
+   RNTupleWriteOptions options;
+   options.SetCompression(0);
+   auto ntuple = RNTupleWriter::Recreate(std::move(model), kNtupleName, filename, options);
+
+   for (size_t i = 0; i < nEntries; ++i) {
+      *field[0] = static_cast<float>(i);
+      *field[1] = static_cast<float>(i) + 0.1f;
+      *field[2] = static_cast<float>(i) + 1.1f;
+      ntuple->Fill();
+      if (i % 10000 == 0)
+         printf("Wrote %lu entries\r", (unsigned long)i);
+   }
+   printf("Wrote %lu entries\n", (unsigned long)nEntries);
+}

--- a/compare/hugefile/test_parquet.cc
+++ b/compare/hugefile/test_parquet.cc
@@ -1,0 +1,87 @@
+#include "util_arrow.h"
+
+#include <arrow/io/api.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/arrow/writer.h>
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+using FloatArray = arrow::FloatArray;
+
+static constexpr size_t kDefaultWriteTableChunkSize = 64000;
+
+std::shared_ptr<arrow::Schema> InitSchema() {
+   using namespace arrow;
+   return schema({
+       field("field_0", float32()),
+       field("field_1", float32()),
+       field("field_2", float32()),
+     });
+}
+
+void Hugefile_Read(const std::string &filename) {
+   std::shared_ptr<arrow::io::ReadableFile> infile;
+   PARQUET_ASSIGN_OR_THROW(infile,
+                           arrow::io::ReadableFile::Open(filename));
+   std::unique_ptr<parquet::arrow::FileReader> reader;
+   PARQUET_THROW_NOT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(),
+                                                 &reader));
+   reader->set_use_threads(true);
+
+   std::shared_ptr<arrow::Schema> schema;
+   reader->GetSchema(&schema);
+   std::vector<int> columns{0, 1, 2};
+   std::shared_ptr<arrow::Table> table;
+
+   size_t count = 0;
+   for (size_t row_group = 0, num_row_groups = reader->num_row_groups();
+        row_group < num_row_groups; ++row_group) {
+      reader->ReadRowGroup(row_group, columns, &table);
+      auto field0 = std::static_pointer_cast<FloatArray>(table->GetColumnByName("field_0")->chunk(0));
+      auto field1 = std::static_pointer_cast<FloatArray>(table->GetColumnByName("field_1")->chunk(0));
+      auto field2 = std::static_pointer_cast<FloatArray>(table->GetColumnByName("field_2")->chunk(0));
+      for (int64_t i = 0; i < table->num_rows(); ++i) {
+         (void)field0->Value(i);
+         (void)field1->Value(i);
+         (void)field2->Value(i);
+         count++;
+      }
+      printf("Read %lu entries\r", (unsigned long)count);
+   }
+}
+
+void Hugefile_Write(const std::string &filename, size_t nEntries) {
+   parquet::WriterProperties::Builder props;
+   props.data_pagesize(64 * 1024); // match RNTuple defaults for page/cluster size
+   props.max_row_group_length(50 * 1000 * 1000);
+   props.encoding(parquet::Encoding::PLAIN);
+   props.disable_dictionary();
+   props.compression(parquet::Compression::UNCOMPRESSED);
+
+   auto schema = InitSchema();
+
+   std::shared_ptr<arrow::io::FileOutputStream> outfile;
+   PARQUET_ASSIGN_OR_THROW(outfile,
+                           arrow::io::FileOutputStream::Open(filename));
+   std::unique_ptr<parquet::arrow::FileWriter> writer;
+   PARQUET_THROW_NOT_OK(parquet::arrow::FileWriter::Open(*schema, arrow::default_memory_pool(), outfile, props.build(),
+                                                         &writer));
+   ArrowTableBuilder<
+     /*field_0*/arrow::FloatBuilder,
+     /*field_1*/arrow::FloatBuilder,
+     /*field_2*/arrow::FloatBuilder
+     > tblBuilder(schema,
+                  kDefaultWriteTableChunkSize,
+                  [&writer](std::shared_ptr<arrow::Table> table) { writer->WriteTable(*table, kDefaultWriteTableChunkSize); });
+   for (size_t i = 0; i < nEntries; ++i) {
+      tblBuilder << std::make_tuple(static_cast<float>(i),
+                                    static_cast<float>(i) + 0.1f,
+                                    static_cast<float>(i) + 1.1f);
+      if (i % 10000 == 0)
+         printf("Wrote %lu entries\r", (unsigned long)i);
+   }
+   printf("Wrote %lu entries\n", (unsigned long)nEntries);
+}

--- a/compare/hugefile/test_ttree.cc
+++ b/compare/hugefile/test_ttree.cc
@@ -1,0 +1,52 @@
+#include <TFile.h>
+#include <TTree.h>
+
+#include <cstdio>
+#include <limits>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+static constexpr const char *kTreeName = "hugefile";
+
+void Hugefile_Read(const std::string &filename) {
+   std::unique_ptr<TFile> file{TFile::Open(filename.c_str(), "READ")};
+   auto tree = file->Get<TTree>(kTreeName);
+
+   float field[3]{};
+   for (size_t i = 0; i < std::extent<decltype(field)>::value; ++i)
+     tree->SetBranchAddress(("field_" + std::to_string(i)).c_str(), &field[i]);
+
+   auto nEntries = tree->GetEntries();
+   for (decltype(nEntries) i = 0; i < nEntries; ++i) {
+      tree->LoadTree(i);
+      tree->GetEntry(i);
+      if (i % 10000 == 0)
+         printf("Read %lu entries\r", (unsigned long)i);
+   }
+   printf("Read %lu entries\n", (unsigned long)nEntries);
+}
+
+void Hugefile_Write(const std::string &filename, size_t nEntries) {
+   TTree::SetMaxTreeSize(std::numeric_limits<Long_t>::max());
+   std::unique_ptr<TFile> file{TFile::Open(filename.c_str(), "RECREATE")};
+   file->SetCompressionLevel(ROOT::RCompressionSetting::ELevel::kUncompressed);
+   auto tree = std::make_unique<TTree>(kTreeName, kTreeName);
+
+   float field[3]{};
+   for (size_t i = 0; i < std::extent<decltype(field)>::value; ++i) {
+      auto branchName = "field_" + std::to_string(i);
+      tree->Branch(branchName.c_str(), &field[i], (branchName + "/F").c_str());
+   }
+
+   for (size_t i = 0; i < nEntries; ++i) {
+      field[0] = static_cast<float>(i);
+      field[1] = static_cast<float>(i) + 0.1f;
+      field[2] = static_cast<float>(i) + 1.1f;
+      tree->Fill();
+      if (i % 10000 == 0)
+         printf("Wrote %lu entries\r", (unsigned long)i);
+   }
+   tree->Write();
+   printf("Wrote %lu entries\n", (unsigned long)nEntries);
+}


### PR DESCRIPTION
This pull request integrates some tests with huge files (10GB, 100GB, 250GB, and 1TB) for RNTuple, TTree, Parquet, and HDF5 {row,column}-wise.

All the tests use 3 `float` fields and a sufficiently large number of entries.  Running the tests requires `dstat` (or [dool](https://github.com/scottchiefbaker/dool)) to periodically report CPU and memory usage.