### PR TITLE
Fix `ntuple_info`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ $(DATA_ROOT)/$(SAMPLE_cms)~%.ntuple: $(DATA_ROOT)/$(SAMPLE_cms)~none.root gen_cm
 
 ### BINARIES ###################################################################
 
-ntuple_info: ntuple_info.C libH1event.so
+ntuple_info: ntuple_info.C
 	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 
 ntuple_dump: ntuple_dump.C

--- a/ntuple_info.C
+++ b/ntuple_info.C
@@ -4,8 +4,11 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 
-#include "h1event.h"
+#include <unistd.h>
+
+//#include "h1event.h"
 //#include "include_cms/classes.hxx"
 
 using ENTupleInfo = ROOT::Experimental::ENTupleInfo;
@@ -19,15 +22,32 @@ void ntuple_info(std::string fileName, std::string ntupleName)
 }
 
 void Usage(char *progname) {
-   std::cout << "Usage: " << progname << " file-name ntuple-name" << std::endl;
+   std::cout << "Usage: " << progname << " [-l additional_lib.so] FILE_NAME NTUPLE_NAME" << std::endl;
 }
 
 int main(int argc, char **argv) {
-   if (argc < 3) {
+   int c;
+   std::vector<std::string> libs;
+   while ((c = getopt(argc, argv, "hl:")) != -1) {
+      switch (c) {
+      case 'h':
+         Usage(argv[0]);
+         return 0;
+      case 'l':
+         libs.emplace_back(optarg);
+         break;
+      default:
+         fprintf(stderr, "Unknown option: -%c\n", c);
+         Usage(argv[0]);
+         return 1;
+      }
+   }
+   if ((argc - optind) != 2) {
       Usage(argv[0]);
       return 1;
    }
-   gSystem->Load("include_cms/libClasses.so");
-   gSystem->Load("libH1event.so");
-   ntuple_info(argv[1], argv[2]);
+
+   for (const auto &libpath : libs)
+      gSystem->Load(libpath.c_str());
+   ntuple_info(argv[optind], argv[optind+1]);
 }


### PR DESCRIPTION
This PR fixes the compilation of `ntuple_info` (see changes below).
- Fix `Makefile`
- Additionally, allow the program to take a list of additional libraries to load (`-l` command-line option).