### PR TITLE
Fix gen_h1 call for RNTuple conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ $(DATA_ROOT)/$(SAMPLE_h1)~none.root: $(MASTER_h1)
 $(DATA_ROOT)/$(SAMPLE_h1X10)~%.root: $(DATA_ROOT)/$(SAMPLE_h1)~none.root
 	hadd -O -f$(COMPRESSION_$*) $@ $< $< $< $< $< $< $< $< $< $<
 
-$(DATA_ROOT)/$(SAMPLE_h1X10)~%.ntuple: $(DATA_ROOT)/$(SAMPLE_h1)~none.root gen_h1
-	./gen_h1 -b10 -o $(shell dirname $@) -c $* $<
+$(DATA_ROOT)/$(SAMPLE_h1X10)~%.ntuple: $(DATA_ROOT)/$(SAMPLE_h1X10)~none.root gen_h1
+	./gen_h1 -i $< -o $(shell dirname $@) -c $*
 
 
 $(DATA_ROOT)/$(SAMPLE_cms)~none.root: $(MASTER_cms)


### PR DESCRIPTION
Since commit be383743e1 ("use importer and uniform RDF code in H1 benchmark"), the `gen_h1` tool doesn't have the `-b` parameter anymore to specify the `bloatFactor`. Instead use the 10x input file.