### PR TITLE
Interpret cluster bunch size < 1 to disable the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Each benchmark takes the same input parameters:
     - `-p` show the tree/ntuple performance statistics
     - `-r` run the benchmark with RDataFrame instead of hand-written event loop
     - `-m` enable implicit multi-threading (paralle RNTuple page decompression, parallel RDF event loop)
+    - `-x` cluster bunch size; a value less than 1 will disable the cluster cache
 
 The real-time timing uses std::chrono::steady_clock and starts with the second
 event (direct access) or with an artificial first filter (RDF).

--- a/atlas.cxx
+++ b/atlas.cxx
@@ -52,7 +52,11 @@ static ROOT::Experimental::RNTupleReadOptions GetRNTupleOptions() {
    using RNTupleReadOptions = ROOT::Experimental::RNTupleReadOptions;
 
    RNTupleReadOptions options;
-   options.SetClusterBunchSize(g_cluster_bunch_size);
+   if (g_cluster_bunch_size < 1) {
+      options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOff);
+   } else {
+      options.SetClusterBunchSize(g_cluster_bunch_size);
+   }
    return options;
 }
 

--- a/cms.cxx
+++ b/cms.cxx
@@ -38,7 +38,11 @@ static ROOT::Experimental::RNTupleReadOptions GetRNTupleOptions() {
    using RNTupleReadOptions = ROOT::Experimental::RNTupleReadOptions;
 
    RNTupleReadOptions options;
-   options.SetClusterBunchSize(g_cluster_bunch_size);
+   if (g_cluster_bunch_size < 1) {
+      options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOff);
+   } else {
+      options.SetClusterBunchSize(g_cluster_bunch_size);
+   }
    return options;
 }
 

--- a/h1.cxx
+++ b/h1.cxx
@@ -43,7 +43,11 @@ static ROOT::Experimental::RNTupleReadOptions GetRNTupleOptions() {
    using RNTupleReadOptions = ROOT::Experimental::RNTupleReadOptions;
 
    RNTupleReadOptions options;
-   options.SetClusterBunchSize(g_cluster_bunch_size);
+   if (g_cluster_bunch_size < 1) {
+      options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOff);
+   } else {
+      options.SetClusterBunchSize(g_cluster_bunch_size);
+   }
    return options;
 }
 

--- a/lhcb.cxx
+++ b/lhcb.cxx
@@ -45,7 +45,11 @@ static ROOT::Experimental::RNTupleReadOptions GetRNTupleOptions() {
    using RNTupleReadOptions = ROOT::Experimental::RNTupleReadOptions;
 
    RNTupleReadOptions options;
-   options.SetClusterBunchSize(g_cluster_bunch_size);
+   if (g_cluster_bunch_size < 1) {
+      options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOff);
+   } else {
+      options.SetClusterBunchSize(g_cluster_bunch_size);
+   }
    return options;
 }
 


### PR DESCRIPTION
That is quite useful for easy tests on the command line.