### PR TITLE
Ntuple change compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS_CUSTOM = -std=c++14 -Wall -pthread -Wall -g -O2
+CXXFLAGS_CUSTOM = -pthread -Wall -g -O2
 ifeq ($(shell root-config --cflags),)
   $(error Cannot find root-config. Please source thisroot.sh)
 endif
@@ -167,6 +167,9 @@ ntuple_info: ntuple_info.C
 	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 
 ntuple_dump: ntuple_dump.C
+	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
+
+ntuple_change_compression: ntuple_change_compression.cxx
 	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 
 tree_info: tree_info.C

--- a/ntuple_change_compression.cxx
+++ b/ntuple_change_compression.cxx
@@ -1,0 +1,76 @@
+/*
+  ntuple_change_compression
+
+  A small utility used to test the capability of RNTupleMerger to change compression of its inputs.
+  Accepts one or more ROOT input files containing one or more RNTuples and outputs one file with
+  all the RNTuples merged with possibly changed compression algorithm and level.
+
+  @author Giacomo Parolini, 2024
+*/
+#include <ROOT/RLogger.hxx>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleMerger.hxx>
+#include <ROOT/RPageStorageFile.hxx>
+#include <TFile.h>
+#include <TROOT.h>
+#include <ROOT/RNTupleWriteOptions.hxx>
+#include <iostream>
+
+using namespace ROOT::Experimental;
+using namespace ROOT::Experimental::Internal;
+using namespace std::chrono;
+
+int main(int argc, char **argv) {
+  if (argc < 5) {
+    fprintf(stderr, "Usage: %s <compression_settings> <ntuple_file_out> <ntuple_name> <ntuple_file1.root> [ntuple_file2.root ...]\n", argv[0]);
+    fprintf(stderr, "Common compression settings:\n\t-1: preserve;\n\t0: uncompressed\n\t505: Zstd\n\t207: LZMA\n");
+    return 1;
+  }
+
+#ifdef R__USE_IMT
+  ROOT::EnableImplicitMT();
+#endif
+
+  auto noWarn = RLogScopedVerbosity(NTupleLog(), ELogLevel::kError);
+
+  const int compSettings = std::atoi(argv[1]);
+  const char *ntuple_file_out = argv[2];
+  const char *ntuple_name = argv[3];
+  std::vector<const char *> ntuple_files;
+  for (int i = 4; i < argc; ++i)
+    ntuple_files.push_back(argv[i]);
+
+  std::vector<std::unique_ptr<RPageSource>> srcs;
+  std::vector<RPageSource *> srcsRaw;
+  srcs.reserve(ntuple_files.size());
+  srcsRaw.reserve(ntuple_files.size());
+
+  for (const char *ntuple_file : ntuple_files) {
+    auto file = std::unique_ptr<TFile>(TFile::Open(ntuple_file));
+    if (!file)
+      return 1;
+
+    auto *anchor = file->Get<RNTuple>(ntuple_name);
+    if (!anchor) {
+      std::cerr << "Error reading RNTuple " << ntuple_name << " from " << ntuple_file << ": skipping.\n";
+      continue;
+    }
+    auto src = RPageSourceFile::CreateFromAnchor(*anchor);
+    auto &s = srcs.emplace_back(std::move(src));
+    srcsRaw.push_back(s.get());
+  }
+
+  auto dst = RPageSinkFile { ntuple_name, ntuple_file_out, RNTupleWriteOptions {} };
+
+  RNTupleMerger merger;
+  RNTupleMergeOptions merge_opts;
+  merge_opts.fCompressionSettings = compSettings;
+  merger.Merge(srcsRaw, dst, merge_opts);
+
+  std::cout << "Merged " << srcsRaw.size() << " ntuples.";
+  if (compSettings != -1)
+    std::cout << " Compression changed to " << compSettings << ".";
+  std::cout << "\nOut file is " << ntuple_file_out << "\n";
+
+  return 0;
+}

--- a/ntuple_dump.C
+++ b/ntuple_dump.C
@@ -3,7 +3,6 @@
  */
 
 #include <ROOT/RNTupleDescriptor.hxx>
-// #include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RPageStorage.hxx>
 


### PR DESCRIPTION
Adding utility to test RNTupleMerger and its feature of changing compression.

Depends on https://github.com/root-project/root/pull/15992

(as a bonus, also make `ntuple_dump.C` compile again)