### PR TITLE
add ntuple_dump_exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ ntuple_info: ntuple_info.C
 ntuple_dump: ntuple_dump.C
 	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 
+ntuple_dump_exporter: ntuple_dump_exporter.cxx
+	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
+
 ntuple_change_compression: ntuple_change_compression.cxx
 	g++ $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 

--- a/ntuple_dump_exporter.cxx
+++ b/ntuple_dump_exporter.cxx
@@ -1,0 +1,32 @@
+#include <ROOT/RNTupleExporter.hxx>
+#include <ROOT/RPageStorage.hxx>
+#include <ROOT/RLogger.hxx>
+#include <cstdio>
+
+using namespace ROOT::Experimental;
+using namespace ROOT::Experimental::Internal;
+
+int main(int argc, char **argv)
+{
+  if (argc != 4) {
+    printf("Usage: %s <output_dir> <input_file> <ntuple_name>\n", argv[0]);
+    return 1;
+  }
+
+  const char *output_dir = argv[1];
+  const char *input_file = argv[2];
+  const char *ntuple_name = argv[3];
+
+  auto source = RPageSource::Create(ntuple_name, input_file);
+
+  ROOT::RLogScopedVerbosity verbosity(ROOT::ELogLevel::kInfo);
+  
+  RNTupleExporter::RPagesOptions opts {};
+  opts.fOutputPath = output_dir;
+  // NOTE: If you want to filter out some specific columns, do something like this:
+  // opts.fColumnTypeFilter.fType = RNTupleExporter::EFilterType::kWhitelist;
+  // opts.fColumnTypeFilter.fSet.insert(EColumnType::kReal64);
+  RNTupleExporter::ExportPages(*source, opts);
+
+  return 0;
+}


### PR DESCRIPTION
Adding a RNTupleExporter-based `ntuple_dump`.
Not removing the other because it might still be useful to hack stuff in that we don't want in the "official" exporter.